### PR TITLE
Use a slice of strings for the labels instead of a map[string]struct{}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+### Build
+* Fixed issues with ordering of values, we now respect the order specified in the query
+
 ## 0.2.0 
 
 ### Build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rockset-backend-datasource",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Rockset backend datasource",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -34,8 +34,8 @@
       }
     ],
     "screenshots": [],
-    "version": "0.2.0",
-    "updated": "2023-01-13"
+    "version": "0.2.1",
+    "updated": "2023-11-05"
   },
   "dependencies": {
     "grafanaDependency": "^9.2.5",


### PR DESCRIPTION
There seems to be no value having a struct because we store an empty struct so what gives?
This makes sure that whatever is the order in the query is what we have for the ordering of labels